### PR TITLE
Revert "Update docker-compose to include `HAB_LICENSE` for Habitat 0.81 release."

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ hab pkg export docker results/learn-chef-haproxy-1.6.11-20180105200724-x86_64-
 ## Run
 
 ```
-$ HAB_LICENSE=accept-no-persist docker-compose up -d
+$ docker-compose up -d
 $ curl localhost:8000/cgi-bin/hello-world
 $ docker-compose down
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,10 @@
 version: '3'
 services:
   web-1:
-    environment:
-      - HAB_LICENSE
     image: $HAB_ORIGIN/webapp
     environment:
      - HAB_LICENSE=accept-no-persist
   web-2:
-    environment:
-      - HAB_LICENSE
     image: $HAB_ORIGIN/webapp
     environment:
      - HAB_LICENSE=accept-no-persist
@@ -16,8 +12,6 @@ services:
     depends_on:
       - web-1
   load-balancer:
-    environment:
-      - HAB_LICENSE
     image: $HAB_ORIGIN/haproxy
     environment:
      - HAB_LICENSE=accept-no-persist


### PR DESCRIPTION
Merged incorrect pull request. Reverting.

Reverts learn-chef/hab-two-tier#12