### PR TITLE
Fix environment key already defined

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,10 @@
 version: '3'
 services:
   web-1:
-    environment:
-      - HAB_LICENSE
     image: $HAB_ORIGIN/webapp
     environment:
      - HAB_LICENSE=accept-no-persist
   web-2:
-    environment:
-      - HAB_LICENSE
     image: $HAB_ORIGIN/webapp
     environment:
      - HAB_LICENSE=accept-no-persist
@@ -16,8 +12,6 @@ services:
     depends_on:
       - web-1
   load-balancer:
-    environment:
-      - HAB_LICENSE
     image: $HAB_ORIGIN/haproxy
     environment:
      - HAB_LICENSE=accept-no-persist


### PR DESCRIPTION
This might be a duplicate of other pull requests. I do see some pull requests changing code around this area. 

Even though this gets around the issue with the duplicate environment key already being stated, the application still does not stay up and running, but simply exits.

```
$ docker-compose -p habquickstart up -d
[+] Building 0.0s (0/0)                                                                                                                                               docker:desktop-linux
[+] Running 4/4
 ✔ Network habquickstart_default            Created                                                                                                                                   0.0s
 ✔ Container habquickstart-web-1-1          Started                                                                                                                                   0.0s
 ✔ Container habquickstart-web-2-1          Started                                                                                                                                   0.0s
 ✔ Container habquickstart-load-balancer-1  Started                                                                                                                                   0.0s
 ```